### PR TITLE
Fix bug in YML config retrieval

### DIFF
--- a/lcci/configuration.py
+++ b/lcci/configuration.py
@@ -43,4 +43,4 @@ class Configuration(object):
                 self.githubapitoken = cfg['main']['github-api-token']
 
     def get_tool_repository(self, filter = None):
-        return ToolRepository(self.githubapitoken, self.volumes['/tools'], filter)
+        return ToolRepository(self.githubapitoken, self.volumes['tools'], filter)


### PR DESCRIPTION
Last version in the master branch does not work on my machine and in reference Docker image, because it fails to resolve the "/tools" YML entry