### PR TITLE
Add support of Building Tools in a Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM librecores/librecores-ci
+LABEL Description="LCCI Python Image" Vendor="LibreCores project" Version="0.1"
+
+VOLUME /tools
+
+WORKDIR /home/lcci-python
+COPY ./ /home/lcci-python
+
+RUN python setup.py build
+RUN python setup.py install
+
+COPY lcci.sample.yml /home/lcci-python/lcci.yml

--- a/README.rst
+++ b/README.rst
@@ -2,3 +2,24 @@ LibreCores.org CI Tool
 ======================
 
 This is the tool to administrate LibreCores.org Continuous Integration (lcci) instances.
+
+### Usage
+
+TODO: Guidelines will be deployed soon
+
+### Docker image for deploying tools
+
+Current image version uses a hardcoded "lcci-tools" volume to deploy tools.
+All available tools are listed here: https://github.com/lccitools
+
+Install a particular tool:
+
+```
+docker run --rm -e DOCKER_HOST=${DOCKER_HOST} librecores/lcci-python lcci tools install verilator:3.902
+```
+
+Install a whole „standard tool package“:
+
+```
+docker run --rm -e DOCKER_HOST=${DOCKER_HOST} librecores/lcci-python lcci tools install lcci-2017.1
+```

--- a/lcci.sample.yml
+++ b/lcci.sample.yml
@@ -1,0 +1,5 @@
+#main:
+#  github-api-token: <TOKEN>
+volumes:
+  #TODO: Make it confurable via API
+  tools: lcci-tools


### PR DESCRIPTION
This pull request adds a Docker image, which can be used to quickly deploy tools to a Docker volume without deploying a local environment.

I used it to spin the Endian Swapper demo in #31